### PR TITLE
feat: Add BackupRadar MCP Server with Mockoon-powered offline testing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "BACKUPRADAR"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ MCP server for HaloPSA API integration, enabling ticket management and reporting
 
 ---
 
+### 🔄 BackupRadar MCP Server
+**Package:** `@adamhancock/backupradar-mcp`  
+**Version:** 0.1.0
+
+MCP server for BackupRadar API integration, focused on backup listing, inspection, and result retrieval.
+
+**Features:**
+- Backup policy search with familiar filters and pagination
+- Single backup detail retrieval by ID
+- Backup execution result inspection via `/backups/{backupId}/results`
+
+[View Package →](./packages/backupradar-mcp)
+
+---
+
 ### 🔧 ConnectWise RMM MCP Server
 **Package:** `@adamhancock/connectwisermm-mcp`  
 **Version:** 0.1.0
@@ -82,6 +97,7 @@ Each MCP server can be installed independently using npm or pnpm:
 # Install a specific MCP server
 npm install @adamhancock/ninjarmm-mcp
 npm install @adamhancock/halopsa-mcp
+npm install @adamhancock/backupradar-mcp
 npm install @adamhancock/connectwisermm-mcp
 npm install @adamhancock/connectwisepsa-mcp
 ```
@@ -116,6 +132,17 @@ CONNECTWISE_PSA_URL=https://api-na.myconnectwise.net
 CONNECTWISE_CLIENT_ID=your_client_id
 CONNECTWISE_PUBLIC_KEY=your_public_key
 CONNECTWISE_PRIVATE_KEY=your_private_key
+```
+
+### BackupRadar
+```env
+BACKUPRADAR_BASE_URL=https://api.backupradar.com/v2
+BACKUPRADAR_API_KEY=your_api_key
+
+# Optional
+BACKUPRADAR_API_KEY_HEADER=ApiKey
+BACKUPRADAR_TIMEOUT_MS=30000
+BACKUPRADAR_USER_AGENT=my-mcp-integration/1.0
 ```
 
 ## Development
@@ -174,6 +201,7 @@ Each package may have its own license. Please check the individual package direc
 
 - NinjaOne RMM MCP: MIT
 - HaloPSA MCP: ISC
+- BackupRadar MCP: ISC
 - ConnectWise RMM MCP: ISC
 - ConnectWise PSA MCP: ISC
 

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.13.1"
+  "packageManager": "pnpm@10.13.1",
+  "devDependencies": {
+    "@modelcontextprotocol/inspector": "^0.17.0"
+  }
 }

--- a/packages/backupradar-mcp/.env.example
+++ b/packages/backupradar-mcp/.env.example
@@ -1,0 +1,12 @@
+BACKUPRADAR_API_KEY=your_api_key
+BACKUPRADAR_BASE_URL=https://api.backupradar.com/v2
+
+# Optional overrides
+# BACKUPRADAR_API_KEY_HEADER=ApiKey
+# BACKUPRADAR_TIMEOUT_MS=30000
+# BACKUPRADAR_USER_AGENT=my-mcp-integration/1.0
+
+# Mockoon demo
+# BACKUPRADAR_BASE_URL=http://lvh.me:3000
+# BACKUPRADAR_API_KEY=demo-key
+# BACKUPRADAR_API_KEY_HEADER=ApiKey

--- a/packages/backupradar-mcp/MockoonBackupRadar.json
+++ b/packages/backupradar-mcp/MockoonBackupRadar.json
@@ -1,0 +1,416 @@
+{
+  "uuid": "e090005d-6371-4d90-b35a-db12b1c16545",
+  "lastMigration": 33,
+  "name": "Backup Radar API - 2.0",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3000,
+  "hostname": "lvh.me",
+  "folders": [],
+  "routes": [
+    {
+      "uuid": "735bb708-45d4-472c-badd-f56cbd467bc2",
+      "type": "http",
+      "documentation": "Get backups with pagination.",
+      "method": "get",
+      "endpoint": "backups",
+      "responses": [
+        {
+          "uuid": "e8b500e9-5842-47fa-853d-66058903ea07",
+          "body": "\"Invalid ApiKey\"",
+          "latency": 0,
+          "statusCode": 401,
+          "label": "Unauthorized (missing/empty ApiKey)",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rulesOperator": "OR",
+          "rules": [
+            {
+              "target": "header",
+              "modifier": "ApiKey",
+              "operator": "null",
+              "value": "",
+              "invert": false
+            },
+            {
+              "target": "header",
+              "modifier": "ApiKey",
+              "operator": "equals",
+              "value": "",
+              "invert": false
+            }
+          ],
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
+          "uuid": "ab9a7ee8-e978-4191-b9f8-0152124ae109",
+          "body": "{{!-- ===== Query params with defaults/coercion ===== --}}\n{{setVar 'pageSize'        (parseInt (queryParamRaw 'Size' '25'))}}\n{{setVar 'page'            (parseInt (queryParamRaw 'Page' '1'))}}\n{{setVar 'historyDays'     (parseInt (queryParamRaw 'historyDays' '365'))}}\n{{setVar 'seedDate'        (queryParamRaw 'date' '')}}\n\n{{!-- Specific filters (single-value only; MCP should send one value) --}}\n{{setVar 'companyFilter'   (queryParamRaw 'searchCompanyName' '')}}\n{{setVar 'methodFilter'    (queryParamRaw 'searchBackupMethod' '')}}\n{{setVar 'jobFilter'       (queryParamRaw 'searchJobName' '')}}\n{{setVar 'deviceFilter'    (queryParamRaw 'searchDeviceName' '')}}\n{{setVar 'tagFilter'       (queryParamRaw 'searchTag' '')}}\n{{setVar 'tooltipFilter'   (queryParamRaw 'searchTooltip' '')}}\n{{setVar 'statusFilter'    (queryParamRaw 'statuses' '')}}      {{!-- single status value --}}\n{{setVar 'filterScheduled' (queryParamRaw 'filterScheduled' '')}}\n{{setVar 'daysNoSuccess'   (queryParamRaw 'daysWithoutSuccess' '')}}\n{{setVar 'policyIdRaw'     (queryParamRaw 'policyIds' '')}}     {{!-- single id (if multiple, MCP should send the first) --}}\n\n{\n  \"Total\": {{int 1 99999}},\n  \"Page\": {{getVar 'page'}},\n  \"PageSize\": {{getVar 'pageSize'}},\n  \"TotalPages\": {{int 1 500}},\n  \"Results\": [\n    {{#repeat (getVar 'pageSize')}}\n      {{!-- ===== per-row resolved values (choose filter OR faker) ===== --}}\n\n      {{!-- Company --}}\n      {{#if (getVar 'companyFilter')}}\n        {{setVar 'rowCompany' (getVar 'companyFilter')}}\n      {{else}}\n        {{setVar 'rowCompany' (faker 'company.name')}}\n      {{/if}}\n\n      {{!-- Method --}}\n      {{#if (getVar 'methodFilter')}}\n        {{setVar 'rowMethod' (getVar 'methodFilter')}}\n      {{else}}\n        {{setVar 'rowMethod' (faker 'helpers.arrayElement' (array 'Veeam' 'Datto' 'AWS' 'Altaro' 'BackupExec' 'Windows Backups' 'Replibit API'))}}\n      {{/if}}\n\n      {{!-- Device --}}\n      {{#if (getVar 'deviceFilter')}}\n        {{setVar 'rowDevice' (getVar 'deviceFilter')}}\n      {{else}}\n        {{setVar 'rowDevicePrefix' (faker 'hacker.abbreviation')}}\n        {{setVar 'rowDeviceNum' (int 10 99)}}\n      {{/if}}\n\n      {{!-- Job --}}\n      {{#if (getVar 'jobFilter')}}\n        {{setVar 'rowJob' (getVar 'jobFilter')}}\n      {{else}}\n        {{setVar 'rowJobNoun' (faker 'word.noun')}}\n        {{setVar 'rowJobAdj'  (faker 'word.adjective')}}\n      {{/if}}\n\n      {{!-- Device type --}}\n      {{setVar 'rowDeviceType' (faker 'helpers.arrayElement' (array 'Server' 'Workstation'))}}\n\n      {{!-- Status (single filter value if provided) --}}\n      {{#if (getVar 'statusFilter')}}\n        {{setVar 'rowStatusName' (getVar 'statusFilter')}}\n      {{else}}\n        {{setVar 'rowStatusName' (faker 'helpers.arrayElement' (array 'Success' 'Warning' 'Failure' 'No Result'))}}\n      {{/if}}\n\n      {{!-- Backup type: id + matching name --}}\n      {{setVar 'rowBackupTypeId' (faker 'helpers.arrayElement' (array 0 1))}}\n      {{#if (eq (getVar 'rowBackupTypeId') 1)}}\n        {{setVar 'rowBackupTypeName' 'Alert'}}\n      {{else}}\n        {{setVar 'rowBackupTypeName' 'Backup'}}\n      {{/if}}\n\n      {{!-- Tags: ensure searchTag is present if provided; total extra tags 0..2 --}}\n      {{#if (getVar 'tagFilter')}}\n        {{setVar 'rowExtraTags' (int 0 2)}}  {{!-- we will prepend the filter tag --}}\n      {{else}}\n        {{setVar 'rowExtraTags' (int 0 3)}}\n      {{/if}}\n\n      {{!-- Scheduled flag: treat \"true\" (string) as true --}}\n      {{#if (eq (getVar 'filterScheduled') 'true')}}\n        {{setVar 'rowForceScheduled' 'true'}}\n      {{else}}\n        {{setVar 'rowForceScheduled' ''}}\n      {{/if}}\n\n      {{!-- Days without success: numeric if provided --}}\n      {{#if (getVar 'daysNoSuccess')}}\n        {{setVar 'rowDaysNoSuccess' (parseInt (getVar 'daysNoSuccess'))}}\n      {{else}}\n        {{setVar 'rowDaysNoSuccess' ''}}\n      {{/if}}\n\n      {{!-- BackupId: try to parse provided; else random --}}\n      {{#if (getVar 'policyIdRaw')}}\n        {{setVar 'rowBackupId' (parseInt (getVar 'policyIdRaw'))}}\n      {{else}}\n        {{setVar 'rowBackupId' (int 1 99999)}}\n      {{/if}}\n\n      {{!-- Dates: use seed date for lastResult if given --}}\n      {{#if (getVar 'seedDate')}}\n        {{setVar 'rowLastResult' (getVar 'seedDate')}}\n      {{else}}\n        {{setVar 'rowLastResult' (faker 'date.recent' days=(getVar 'historyDays'))}}\n      {{/if}}\n      {{setVar 'rowLastSuccess' (faker 'date.recent' days=(getVar 'historyDays'))}}\n\n    {\n      \"ticketingCompany\": \"{{getVar 'rowCompany'}}\",\n\n      \"status\": {\n        \"id\": {{int 1 99999}},\n        \"name\": \"{{getVar 'rowStatusName'}}\"\n      },\n\n      \"daysInStatus\": {{float 0 365 2}},\n      \"isVerified\": {{faker 'datatype.boolean'}},\n      \"lastResult\": \"{{getVar 'rowLastResult'}}\",\n      \"lastSuccess\": \"{{getVar 'rowLastSuccess'}}\",\n      \"ticketCount\": {{int 0 99999}},\n      \"failureThreshold\": {{float 0 10 1}},\n      \"treatWarningAsSuccess\": {{faker 'datatype.boolean'}},\n\n      \"note\": {{#if (getVar 'tooltipFilter')}}\n                \"{{getVar 'tooltipFilter'}}\"\n              {{else}}\n                {{#if (faker 'datatype.boolean')}} \"{{faker 'hacker.phrase'}}\" {{else}} null {{/if}}\n              {{/if}},\n\n      \"dayStartHour\": {{int 0 23}},\n\n      \"tags\": [\n        {{#if (getVar 'tagFilter')}}\n          \"{{getVar 'tagFilter'}}\"{{#if (gt (getVar 'rowExtraTags') 0)}},{{/if}}\n        {{/if}}\n        {{#repeat (getVar 'rowExtraTags')}}\n          \"{{faker 'helpers.arrayElement' (array 'Veeam' 'Datto' 'AWS' 'Altaro' 'Important' 'Ignore')}}\"\n          {{#unless @last}},{{/unless}}\n        {{/repeat}}\n      ],\n\n      \"standalone\": {{faker 'datatype.boolean'}},\n\n      \"history\": [\n        {{#repeat (int 0 3)}}\n        {\n          \"status\": {\n            \"id\": {{int 1 99999}},\n            \"name\": \"{{#if (getVar 'statusFilter')}}{{getVar 'statusFilter'}}{{else}}{{faker 'helpers.arrayElement' (array 'Success' 'Warning' 'Failure' 'No Result')}}{{/if}}\"\n          },\n          \"lastResultDate\": \"{{faker 'date.recent' days=(getVar 'historyDays')}}\",\n          \"isScheduled\": {{#if (getVar 'rowForceScheduled')}}true{{else}}{{faker 'datatype.boolean'}}{{/if}},\n          \"daysInStatus\": {{float 0 365 1}},\n          \"date\": \"{{faker 'date.recent' days=(getVar 'historyDays')}}\",\n          \"countFailure\": {{int 0 99999}},\n          \"countWarning\": {{int 0 99999}},\n          \"countSuccess\": {{int 0 99999}},\n          \"countNoResult\": {{int 0 99999}},\n          \"daysSinceLastResult\": {{float 0 365 1}},\n          \"daysSinceLastGoodResult\": {{#if (getVar 'rowDaysNoSuccess')}}{{getVar 'rowDaysNoSuccess'}}{{else}}{{float -1 365 1}}{{/if}},\n          \"resultsCount\": {{int 0 99999}}\n        }{{#unless @last}},{{/unless}}\n        {{/repeat}}\n      ],\n\n      \"backupId\": {{getVar 'rowBackupId'}},\n\n      \"companyName\": \"{{getVar 'rowCompany'}}\",\n      \"deviceName\": \"{{#if (getVar 'deviceFilter')}}{{getVar 'rowDevice'}}{{else}}{{getVar 'rowDevicePrefix'}}-{{getVar 'rowDeviceNum'}}{{/if}}\",\n      \"deviceType\": \"{{getVar 'rowDeviceType'}}\",\n      \"jobName\": \"{{#if (getVar 'jobFilter')}}{{getVar 'rowJob'}}{{else}}{{getVar 'rowJobNoun'}} {{getVar 'rowJobAdj'}} Report{{/if}}\",\n      \"methodName\": \"{{getVar 'rowMethod'}}\",\n\n      \"backupType\": {\n        \"id\": {{getVar 'rowBackupTypeId'}},\n        \"name\": \"{{getVar 'rowBackupTypeName'}}\"\n      }\n    }{{#unless @last}},{{/unless}}\n    {{/repeat}}\n  ]\n}\n",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "OK",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "key": "",
+              "value": ""
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rulesOperator": "OR",
+          "rules": [
+            {
+              "target": "header",
+              "modifier": "ApiKey",
+              "operator": "regex",
+              "value": "^.+$",
+              "invert": false
+            }
+          ],
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
+          "uuid": "504ce7a8-2b0e-4dc7-8693-b5a828828b45",
+          "body": "\"\"",
+          "latency": 0,
+          "statusCode": 429,
+          "label": "Too Many Requests",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "afd5a9a2-3854-4e18-95ad-e5b8b26716b1",
+      "type": "http",
+      "documentation": "Get backups data.",
+      "method": "get",
+      "endpoint": "backups/:backupId",
+      "responses": [
+        {
+          "uuid": "60b140c4-d3b0-490f-866b-fd56f37c9acf",
+          "body": "\"Invalid ApiKey\"",
+          "latency": 0,
+          "statusCode": 401,
+          "label": "Unauthorized (missing/empty ApiKey)",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "rulesOperator": "OR",
+          "rules": [
+            {
+              "target": "header",
+              "modifier": "ApiKey",
+              "operator": "null",
+              "value": "",
+              "invert": false
+            },
+            {
+              "target": "header",
+              "modifier": "ApiKey",
+              "operator": "equals",
+              "value": "",
+              "invert": false
+            }
+          ],
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": [],
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false
+        },
+        {
+          "uuid": "1172a44e-3dec-4464-a3f0-23a79e968c34",
+          "body": "{\n  \"ticketingCompany\": \"{{faker 'company.name'}}\",\n  \"status\": {\n    \"id\": {{faker 'number.int' min=1 max=99999}},\n    \"name\": \"{{faker 'helpers.arrayElement' (array 'Success' 'Warning' 'Failure' 'No Result')}}\"\n  },\n  \"daysInStatus\": {{faker 'number.float' min=0 max=365 precision=0.01}},\n  \"isVerified\": {{faker 'helpers.arrayElement' (array true false)}},\n  \"lastResult\": \"{{faker 'date.recent' days=365}}\",\n  \"lastSuccess\": \"{{faker 'date.recent' days=365}}\",\n  \"ticketCount\": {{faker 'number.int' min=0 max=99999}},\n  \"failureThreshold\": {{faker 'number.float' min=0 max=10 precision=0.1}},\n  \"treatWarningAsSuccess\": {{faker 'helpers.arrayElement' (array true false)}},\n  \"note\": {{#if (faker 'helpers.arrayElement' (array true false))}}\"{{faker 'hacker.phrase'}}\"{{else}}null{{/if}},\n  \"dayStartHour\": {{faker 'number.int' min=0 max=23}},\n  \"tags\": [{{#repeat (faker 'number.int' min=0 max=3)}}\"{{faker 'helpers.arrayElement' (array 'Veeam' 'Datto' 'AWS' 'Altaro' 'Important' 'Ignore')}}\"{{/repeat}}],\n  \"standalone\": {{faker 'helpers.arrayElement' (array true false)}},\n  \"history\": [\n    {{#repeat (faker 'number.int' min=0 max=3)}}\n    {\n      \"status\": {\n        \"id\": {{faker 'number.int' min=1 max=99999}},\n        \"name\": \"{{faker 'helpers.arrayElement' (array 'Success' 'Warning' 'Failure' 'No Result')}}\"\n      },\n      \"lastResultDate\": \"{{faker 'date.recent' days=365}}\",\n      \"isScheduled\": {{faker 'helpers.arrayElement' (array true false)}},\n      \"daysInStatus\": {{faker 'number.float' min=0 max=365 precision=0.1}},\n      \"date\": \"{{faker 'date.recent' days=365}}\",\n      \"countFailure\": {{faker 'number.int' min=0 max=99999}},\n      \"countWarning\": {{faker 'number.int' min=0 max=99999}},\n      \"countSuccess\": {{faker 'number.int' min=0 max=99999}},\n      \"countNoResult\": {{faker 'number.int' min=0 max=99999}},\n      \"daysSinceLastResult\": {{faker 'number.float' min=0 max=365 precision=0.1}},\n      \"daysSinceLastGoodResult\": {{faker 'number.float' min=-1 max=365 precision=0.1}},\n      \"resultsCount\": {{faker 'number.int' min=0 max=99999}}\n    }{{#unless @last}},{{/unless}}\n    {{/repeat}}\n  ],\n  \"backupId\": {{#if (urlParam 'backupId')}}{{urlParam 'backupId'}}{{else}}{{faker 'number.int' min=1 max=99999}}{{/if}},\n  \"companyName\": \"{{faker 'company.name'}}\",\n  \"deviceName\": \"{{faker 'hacker.abbreviation'}}-{{faker 'number.int' min=10 max=99}}\",\n  \"deviceType\": \"{{faker 'helpers.arrayElement' (array 'Server' 'Workstation')}}\",\n  \"jobName\": \"{{faker 'word.noun'}} {{faker 'word.adjective'}} Report\",\n  \"methodName\": \"{{faker 'helpers.arrayElement' (array 'Veeam' 'Datto' 'AWS' 'Altaro' 'BackupExec' 'Windows Backups' 'Replibit API')}}\",\n  \"backupType\": {\n    \"id\": {{faker 'helpers.arrayElement' (array 0 1)}},\n    \"name\": \"{{faker 'helpers.arrayElement' (array 'Backup' 'Alert')}}\"\n  }\n}\n",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "OK",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rulesOperator": "OR",
+          "rules": [
+            {
+              "target": "header",
+              "modifier": "ApiKey",
+              "operator": "regex",
+              "value": "^.+$",
+              "invert": false
+            }
+          ],
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
+          "uuid": "d66fe7f6-8045-4181-afde-0e5b554e2b52",
+          "body": "\"\"",
+          "latency": 0,
+          "statusCode": 400,
+          "label": "Bad Request",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
+          "uuid": "503a5526-9764-48a5-875a-425cb3df3030",
+          "body": "\"\"",
+          "latency": 0,
+          "statusCode": 429,
+          "label": "Too Many Requests",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "60736f4f-2e26-4d40-8bdb-73cd54347243",
+      "type": "http",
+      "documentation": "Get results for backups for date.",
+      "method": "get",
+      "endpoint": "backups/:backupId/results",
+      "responses": [
+        {
+          "uuid": "87fa2290-8d26-4c26-a6f8-d35c3f3ed8ab",
+          "body": "\"Invalid ApiKey\"",
+          "latency": 0,
+          "statusCode": 401,
+          "label": "Unauthorized (missing/empty ApiKey)",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "rulesOperator": "OR",
+          "rules": [
+            {
+              "target": "header",
+              "modifier": "ApiKey",
+              "operator": "null",
+              "value": "",
+              "invert": false
+            },
+            {
+              "target": "header",
+              "modifier": "ApiKey",
+              "operator": "equals",
+              "value": "",
+              "invert": false
+            }
+          ],
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": [],
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false
+        },
+        {
+          "uuid": "3c2281b2-efdd-423a-aa9b-fbe9742b26ce",
+          "body": "{\n  \"Total\": {{faker 'number.int' max=99999}},\n  \"Page\": {{faker 'number.int' max=99999}},\n  \"PageSize\": {{faker 'number.int' max=99999}},\n  \"TotalPages\": {{faker 'number.int' max=99999}},\n  \"Results\": [\n    {\n      \"dateTime\": \"{{faker 'date.recent' 365}}\",\n      \"success\": {{faker 'datatype.boolean'}},\n      \"warning\": {{faker 'datatype.boolean'}},\n      \"failure\": {{faker 'datatype.boolean'}},\n      \"manual\": {{faker 'datatype.boolean'}},\n      \"resultId\": {{faker 'number.int' min=1 max=99999}}\n    }\n  ]\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "OK",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rulesOperator": "OR",
+          "rules": [
+            {
+              "target": "header",
+              "modifier": "ApiKey",
+              "operator": "regex",
+              "value": "^.+$",
+              "invert": false
+            }
+          ],
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
+          "uuid": "8c4783b2-f79c-4b7c-a581-40f2763acf0a",
+          "body": "\"\"",
+          "latency": 0,
+          "statusCode": 429,
+          "label": "Too Many Requests",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    }
+  ],
+  "rootChildren": [
+    {
+      "type": "route",
+      "uuid": "735bb708-45d4-472c-badd-f56cbd467bc2"
+    },
+    {
+      "type": "route",
+      "uuid": "afd5a9a2-3854-4e18-95ad-e5b8b26716b1"
+    },
+    {
+      "type": "route",
+      "uuid": "60736f4f-2e26-4d40-8bdb-73cd54347243"
+    }
+  ],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Access-Control-Allow-Origin",
+      "value": "*"
+    },
+    {
+      "key": "Access-Control-Allow-Methods",
+      "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+    },
+    {
+      "key": "Access-Control-Allow-Headers",
+      "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With, ApiKey"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": [],
+  "callbacks": []
+}

--- a/packages/backupradar-mcp/README.md
+++ b/packages/backupradar-mcp/README.md
@@ -1,0 +1,87 @@
+# BackupRadar MCP Server
+
+Expose BackupRadar backup monitoring data to Model Context Protocol (MCP) clients. This package wraps the BackupRadar REST API and makes common workflows—like reviewing backup jobs or acknowledging alerts—available as MCP tools.
+
+## Highlights
+- Query BackupRadar policies with familiar filters and pagination controls
+- Inspect individual backup records to review configuration details
+- Fetch execution results for a backup and confirm recent outcomes
+- Works seamlessly with the bundled Mockoon environment for offline testing
+
+## Installation
+
+```bash
+pnpm add @adamhancock/backupradar-mcp
+# or
+npm install @adamhancock/backupradar-mcp
+```
+
+## Configuration
+
+Set the required environment variables (usually via `.env`):
+
+```env
+BACKUPRADAR_API_KEY=your_api_key
+BACKUPRADAR_BASE_URL=https://api.backupradar.com/v2
+
+# Optional overrides
+BACKUPRADAR_API_KEY_HEADER=ApiKey
+BACKUPRADAR_TIMEOUT_MS=30000
+BACKUPRADAR_USER_AGENT=my-mcp-integration/1.0
+```
+
+### Mock API (Mockoon)
+
+A ready-to-use Mockoon environment lives at `packages/backupradar-mcp/MockoonBackupRadar.json`. Import it into Mockoon (Desktop or CLI) to exercise the MCP against realistic-but-safe sample data.
+
+- Default host/port: `http://lvh.me:3000`
+- Authentication header: `ApiKey: demo-key`
+- Query parameters such as `SearchByCompanyName`, `SearchByDeviceName`, `SearchByJobName`, `SearchByBackupMethod`, `tags`, `statuses`, `policyIds`, etc. are echoed back in the payload so you can validate filtering and pagination behaviour end-to-end.
+- When no company/policy filter is supplied, additional sample entities are returned so list views still look populated.
+- Note - Support for complex query param combinations is not fully implemented - to test fully, a live backupRadar API connection is recommended!
+
+Sample `.env` for the mock:
+
+```env
+BACKUPRADAR_BASE_URL=http://lvh.me:3000
+BACKUPRADAR_API_KEY=demo-key
+BACKUPRADAR_API_KEY_HEADER=ApiKey
+```
+
+## Available Tools
+
+| Tool | Description |
+| --- | --- |
+| `backupradar_list_backups` | List backups (/backups) with optional filters for company, device, method, status, tags, and paging. |
+| `backupradar_get_backup` | Retrieve a single backup record (/backups/{backupId}) with optional date hinting for history. |
+| `backupradar_get_backup_results` | Fetch execution results for a backup (/backups/{backupId}/results), optionally scoped by date. |
+
+All responses are returned verbatim from the BackupRadar API to preserve schema details for downstream automation.
+
+## Example Usage
+- "List BackupRadar backups tagged `Veeam` that haven’t succeeded in 3 days."
+- "Show the configuration for backup `12004` from yesterday."
+- "Fetch the execution results for backup `12004` on 2025-09-30."
+
+## Development
+
+```bash
+# Install dependencies for the whole monorepo
+pnpm install
+
+# Build just this package
+pnpm --filter backupradar-mcp build
+
+# Run in watch mode with .env support
+cd packages/backupradar-mcp
+pnpm dev
+
+# Launch the MCP inspector for interactive testing
+pnpm inspector
+```
+
+The TypeScript source lives in `src/`. Building compiles to `dist/` for publishing.
+
+## License
+
+ISC

--- a/packages/backupradar-mcp/package.json
+++ b/packages/backupradar-mcp/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@adamhancock/backupradar-mcp",
+  "version": "0.1.0",
+  "description": "MCP server for BackupRadar API",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "backupradar-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepublish": "pnpm run build",
+    "dev": "tsx watch --env-file=.env src/index.ts",
+    "start": "node dist/index.js",
+    "inspect": "node --inspect dist/index.js",
+    "inspector": "npx mcp-inspector tsx --env-file=.env src/index.ts"
+  },
+  "keywords": [
+    "mcp",
+    "backupradar",
+    "monitoring"
+  ],
+  "author": "",
+  "license": "MIT",
+  "packageManager": "pnpm@10.13.1",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.17.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "mcp-inspector": "^1.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/backupradar-mcp/src/backupradar-client.ts
+++ b/packages/backupradar-mcp/src/backupradar-client.ts
@@ -1,0 +1,144 @@
+export interface BackupRadarConfig {
+  baseUrl: string;
+  apiKey: string;
+  apiKeyHeader?: string;
+  timeoutMs?: number;
+  userAgent?: string;
+}
+
+type QueryValue = string | number | boolean | Date | undefined | null;
+export type QueryParams = Record<string, QueryValue | QueryValue[]>;
+
+export class BackupRadarClient {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+  private readonly apiKeyHeader: string;
+  private readonly timeoutMs: number;
+  private readonly userAgent?: string;
+
+  constructor(config: BackupRadarConfig) {
+    if (!config.baseUrl) {
+      throw new Error('BackupRadar baseUrl is required');
+    }
+    if (!config.apiKey) {
+      throw new Error('BackupRadar apiKey is required');
+    }
+
+    this.baseUrl = config.baseUrl.replace(/\/+$/, '');
+    this.apiKey = config.apiKey;
+    this.apiKeyHeader = config.apiKeyHeader || 'ApiKey';
+    this.timeoutMs = config.timeoutMs ?? 30_000;
+    this.userAgent = config.userAgent;
+  }
+
+  async listBackups(params?: QueryParams) {
+    return this.request('GET', '/backups', { query: params });
+  }
+
+  async getBackup(backupId: string | number, params?: QueryParams) {
+    return this.request('GET', `/backups/${backupId}`, { query: params });
+  }
+
+  async getBackupResults(backupId: string | number, params?: QueryParams) {
+    return this.request('GET', `/backups/${backupId}/results`, { query: params });
+  }
+
+  private buildUrl(path: string, query?: QueryParams): string {
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    const url = new URL(`${this.baseUrl}${normalizedPath}`);
+
+    if (query) {
+      Object.entries(query).forEach(([key, value]) => {
+        if (value === undefined || value === null) {
+          return;
+        }
+
+        if (Array.isArray(value)) {
+          value.forEach((entry) => {
+            if (entry !== undefined && entry !== null) {
+              url.searchParams.append(key, this.stringify(entry));
+            }
+          });
+        } else {
+          url.searchParams.append(key, this.stringify(value));
+        }
+      });
+    }
+
+    return url.toString();
+  }
+
+  private stringify(value: QueryValue): string {
+    if (value === undefined || value === null) {
+      return '';
+    }
+
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+
+    return String(value);
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    options: {
+      query?: QueryParams;
+      body?: unknown;
+      headers?: Record<string, string>;
+    } = {}
+  ): Promise<T> {
+    const url = this.buildUrl(path, options.query);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const headers: Record<string, string> = {
+        Accept: 'application/json',
+        [this.apiKeyHeader]: this.apiKey,
+        ...(this.userAgent ? { 'User-Agent': this.userAgent } : {}),
+        ...options.headers,
+      };
+
+      if (options.body !== undefined && options.body !== null) {
+        headers['Content-Type'] = 'application/json';
+      }
+
+      const response = await fetch(url, {
+        method,
+        signal: controller.signal,
+        headers,
+        body: options.body ? JSON.stringify(options.body) : undefined,
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text().catch(() => '');
+        throw new Error(
+          `BackupRadar API error: ${response.status} ${response.statusText}${
+            errorBody ? ` - ${errorBody}` : ''
+          }`
+        );
+      }
+
+      if (response.status === 204) {
+        return undefined as T;
+      }
+
+      const contentType = response.headers.get('content-type');
+      if (contentType && contentType.includes('application/json')) {
+        return (await response.json()) as T;
+      }
+
+      const text = await response.text();
+      return text as unknown as T;
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error(`BackupRadar request timed out after ${this.timeoutMs} ms`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/packages/backupradar-mcp/src/backupradarswagger.json
+++ b/packages/backupradar-mcp/src/backupradarswagger.json
@@ -1,0 +1,1670 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "Backup Radar API - 2.0",
+    "description": "<p><b>Build:</b> 1.0.0-20250826-0602+e69b86a2d6a13f14ff2336bebf0e6b56d5047d1e</p>",
+    "version": "2.0"
+  },
+  "paths": {
+    "/backups": {
+      "get": {
+        "tags": [
+          "Backups"
+        ],
+        "summary": "Get backups with pagination.",
+        "description": "Returns scheduled backups(policies) that satisfy the provided filters and paginate them.\n            \nThrottling policy: not often than 1 request per 0.5 seconds.",
+        "parameters": [
+          {
+            "name": "Page",
+            "in": "query",
+            "description": "Page number to get from the API. Default: 1.",
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "Size",
+            "in": "query",
+            "description": "Size of the page to get from the API. Default: 50. Max page size: 1000.",
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "SearchByCompanyName",
+            "in": "query",
+            "description": "Search by company name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByDeviceName",
+            "in": "query",
+            "description": "Search by device name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByJobName",
+            "in": "query",
+            "description": "Search by job name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByBackupMethod",
+            "in": "query",
+            "description": "Search by backup method.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByTooltip",
+            "in": "query",
+            "description": "Search by backup note.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByTag",
+            "in": "query",
+            "description": "Search by tag.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "DaysWithoutSuccess",
+            "in": "query",
+            "description": "Filter by days without success.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "HistoryDays",
+            "in": "query",
+            "description": "Count of days to get backup history. Default: 0 days(without history). Maximum: 31 days.",
+            "schema": {
+              "maximum": 31,
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "FilterScheduled",
+            "in": "query",
+            "description": "Filter only scheduled backups.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "description": "Date from (Example: 2018-02-14).",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "searchString",
+            "in": "query",
+            "description": "Search string.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "companies",
+            "in": "query",
+            "description": "Filter by companies.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Filter by tags.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "excludeTags",
+            "in": "query",
+            "description": "Exclude the policies with the specific tags.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "backupMethods",
+            "in": "query",
+            "description": "Filter by backup methods.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "deviceTypes",
+            "in": "query",
+            "description": "Filter by device type.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "excludeDeviceTypes",
+            "in": "query",
+            "description": "Exclude the policies with the specific device types.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "statuses",
+            "in": "query",
+            "description": "Filter by statuses.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "policyIds",
+            "in": "query",
+            "description": "Include only the policies with the listed Ids.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "excludeBackupMethods",
+            "in": "query",
+            "description": "Exclude the policies with the specific backup methods.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "policyTypes",
+            "in": "query",
+            "description": "Filter by policy type.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBackup, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":2,"Page":1,"PageSize":10,"TotalPages":1,"Results":[{"ticketingCompany":"CW Company","status":{"id":1,"name":"Success"},"daysInStatus":0.24,"isVerified":false,"lastResult":"2025-10-01T10:42:20","lastSuccess":"2025-10-01T10:42:20","ticketCount":2,"failureThreshold":2.0,"treatWarningAsSuccess":false,"note":"Some note from user","dayStartHour":2,"tags":["Veeam"],"standalone":false,"history":[{"status":{"id":3,"name":"Failure"},"lastResultDate":"2025-09-26T00:00:00","isScheduled":true,"daysInStatus":5.3,"date":"2025-09-26T00:00:00","countFailure":1,"countWarning":0,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":5.0,"daysSinceLastGoodResult":-1.0,"resultsCount":1},{"status":{"id":1,"name":"Success"},"lastResultDate":"2025-09-27T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-27T00:00:00","countFailure":0,"countWarning":0,"countSuccess":1,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":0.3,"resultsCount":1}],"backupId":1000,"companyName":"ABC Company","deviceName":"BR-VK24","deviceType":"Server","jobName":"BR Daily Report","methodName":"Veeam","backupType":{"id":0,"name":"Backup"}},{"ticketingCompany":"CW Company","status":{"id":3,"name":"Failure"},"daysInStatus":0.24,"isVerified":true,"lastResult":"2025-10-01T08:42:20","lastSuccess":"2025-10-01T08:42:20","ticketCount":0,"failureThreshold":2.0,"treatWarningAsSuccess":true,"dayStartHour":0,"tags":["Veeam"],"standalone":false,"history":[{"status":{"id":2,"name":"Warning"},"lastResultDate":"2025-09-29T00:00:00","isScheduled":true,"daysInStatus":2.0,"date":"2025-09-29T00:00:00","countFailure":0,"countWarning":1,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":1.0,"daysSinceLastGoodResult":-1.0,"resultsCount":1},{"status":{"id":3,"name":"Failure"},"lastResultDate":"2025-09-30T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-30T00:00:00","countFailure":1,"countWarning":0,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":-1.0,"resultsCount":1}],"backupId":1000,"companyName":"DEF Company","deviceName":"BR-OD21","deviceType":"Server","jobName":"BR Daily Report","methodName":"Veeam","backupType":{"id":0,"name":"Backup"}}]}
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBackup, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":2,"Page":1,"PageSize":10,"TotalPages":1,"Results":[{"ticketingCompany":"CW Company","status":{"id":1,"name":"Success"},"daysInStatus":0.24,"isVerified":false,"lastResult":"2025-10-01T10:42:20","lastSuccess":"2025-10-01T10:42:20","ticketCount":2,"failureThreshold":2.0,"treatWarningAsSuccess":false,"note":"Some note from user","dayStartHour":2,"tags":["Veeam"],"standalone":false,"history":[{"status":{"id":3,"name":"Failure"},"lastResultDate":"2025-09-26T00:00:00","isScheduled":true,"daysInStatus":5.3,"date":"2025-09-26T00:00:00","countFailure":1,"countWarning":0,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":5.0,"daysSinceLastGoodResult":-1.0,"resultsCount":1},{"status":{"id":1,"name":"Success"},"lastResultDate":"2025-09-27T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-27T00:00:00","countFailure":0,"countWarning":0,"countSuccess":1,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":0.3,"resultsCount":1}],"backupId":1000,"companyName":"ABC Company","deviceName":"BR-VK24","deviceType":"Server","jobName":"BR Daily Report","methodName":"Veeam","backupType":{"id":0,"name":"Backup"}},{"ticketingCompany":"CW Company","status":{"id":3,"name":"Failure"},"daysInStatus":0.24,"isVerified":true,"lastResult":"2025-10-01T08:42:20","lastSuccess":"2025-10-01T08:42:20","ticketCount":0,"failureThreshold":2.0,"treatWarningAsSuccess":true,"dayStartHour":0,"tags":["Veeam"],"standalone":false,"history":[{"status":{"id":2,"name":"Warning"},"lastResultDate":"2025-09-29T00:00:00","isScheduled":true,"daysInStatus":2.0,"date":"2025-09-29T00:00:00","countFailure":0,"countWarning":1,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":1.0,"daysSinceLastGoodResult":-1.0,"resultsCount":1},{"status":{"id":3,"name":"Failure"},"lastResultDate":"2025-09-30T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-30T00:00:00","countFailure":1,"countWarning":0,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":-1.0,"resultsCount":1}],"backupId":1000,"companyName":"DEF Company","deviceName":"BR-OD21","deviceType":"Server","jobName":"BR Daily Report","methodName":"Veeam","backupType":{"id":0,"name":"Backup"}}]}
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBackup, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":2,"Page":1,"PageSize":10,"TotalPages":1,"Results":[{"ticketingCompany":"CW Company","status":{"id":1,"name":"Success"},"daysInStatus":0.24,"isVerified":false,"lastResult":"2025-10-01T10:42:20","lastSuccess":"2025-10-01T10:42:20","ticketCount":2,"failureThreshold":2.0,"treatWarningAsSuccess":false,"note":"Some note from user","dayStartHour":2,"tags":["Veeam"],"standalone":false,"history":[{"status":{"id":3,"name":"Failure"},"lastResultDate":"2025-09-26T00:00:00","isScheduled":true,"daysInStatus":5.3,"date":"2025-09-26T00:00:00","countFailure":1,"countWarning":0,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":5.0,"daysSinceLastGoodResult":-1.0,"resultsCount":1},{"status":{"id":1,"name":"Success"},"lastResultDate":"2025-09-27T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-27T00:00:00","countFailure":0,"countWarning":0,"countSuccess":1,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":0.3,"resultsCount":1}],"backupId":1000,"companyName":"ABC Company","deviceName":"BR-VK24","deviceType":"Server","jobName":"BR Daily Report","methodName":"Veeam","backupType":{"id":0,"name":"Backup"}},{"ticketingCompany":"CW Company","status":{"id":3,"name":"Failure"},"daysInStatus":0.24,"isVerified":true,"lastResult":"2025-10-01T08:42:20","lastSuccess":"2025-10-01T08:42:20","ticketCount":0,"failureThreshold":2.0,"treatWarningAsSuccess":true,"dayStartHour":0,"tags":["Veeam"],"standalone":false,"history":[{"status":{"id":2,"name":"Warning"},"lastResultDate":"2025-09-29T00:00:00","isScheduled":true,"daysInStatus":2.0,"date":"2025-09-29T00:00:00","countFailure":0,"countWarning":1,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":1.0,"daysSinceLastGoodResult":-1.0,"resultsCount":1},{"status":{"id":3,"name":"Failure"},"lastResultDate":"2025-09-30T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-30T00:00:00","countFailure":1,"countWarning":0,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":-1.0,"resultsCount":1}],"backupId":1000,"companyName":"DEF Company","deviceName":"BR-OD21","deviceType":"Server","jobName":"BR Daily Report","methodName":"Veeam","backupType":{"id":0,"name":"Backup"}}]}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Invalid ApiKey"
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Invalid ApiKey"
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Invalid ApiKey"
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": [ ]
+          }
+        ]
+      }
+    },
+    "/backups/bg": {
+      "get": {
+        "tags": [
+          "Backups"
+        ],
+        "summary": "Get backups for BrightGauge with pagination.",
+        "description": "Returns scheduled backups(policies) that satisfy the provided filters and paginate them.\n            \nThrottling policy: not often than 1 request per 0.5 seconds.",
+        "parameters": [
+          {
+            "name": "date",
+            "in": "query",
+            "description": "Date from (Example: 2018-02-14). Default: Today.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "description": "Amount of days to fetch. Default: 1. Max Value: 31.",
+            "schema": {
+              "maximum": 31,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "includeResults",
+            "in": "query",
+            "description": "Include raw results. Default: false.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "includeHistoryDetails",
+            "in": "query",
+            "description": "Include history details (result counts). Default: false.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "Page",
+            "in": "query",
+            "description": "Page number to get from the API. Default: 1.",
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "Size",
+            "in": "query",
+            "description": "Size of the page to get from the API. Default: 50. Max page size: 1000.",
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBrightGaugeBackup, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":2,"Page":1,"PageSize":10,"TotalPages":1,"Results":[{"id":1000,"job":"BR Daily Report","device":"BR-VK24","company":"ABC Company","deviceType":"Server","ticketingCompany":"CW Company","method":"Veeam","isVerified":false,"history":[{"status":{"id":3,"name":"Failure"},"lastResultDate":"2025-09-26T00:00:00","isScheduled":true,"daysInStatus":5.3,"date":"2025-09-26T00:00:00","countFailure":1,"countWarning":0,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":5.0,"daysSinceLastGoodResult":-1.0,"resultsCount":1},{"status":{"id":1,"name":"Success"},"lastResultDate":"2025-09-27T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-27T00:00:00","countFailure":0,"countWarning":0,"countSuccess":1,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":0.3,"resultsCount":1}],"results":{"2025-09-27T00:00:00":[{"dateTime":"2025-09-27T05:00:00","success":true,"warning":false,"failure":false,"manual":false,"resultId":"1000_638945460000000000_1"}],"2025-09-26T00:00:00":[{"dateTime":"2025-09-26T04:00:00","success":true,"warning":false,"failure":false,"manual":false,"resultId":"1000_638944560000000000_4"}]}},{"id":1001,"job":"BR Daily Report","device":"BR-OD21","company":"DEF Company","deviceType":"Server","ticketingCompany":"CW Company","method":"Veeam","isVerified":true,"history":[{"status":{"id":2,"name":"Warning"},"lastResultDate":"2025-09-29T00:00:00","isScheduled":true,"daysInStatus":2.0,"date":"2025-09-29T00:00:00","countFailure":0,"countWarning":1,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":1.0,"daysSinceLastGoodResult":-1.0,"resultsCount":1},{"status":{"id":3,"name":"Failure"},"lastResultDate":"2025-09-30T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-30T00:00:00","countFailure":1,"countWarning":0,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":-1.0,"resultsCount":1}],"results":{}}]}
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBrightGaugeBackup, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":2,"Page":1,"PageSize":10,"TotalPages":1,"Results":[{"id":1000,"job":"BR Daily Report","device":"BR-VK24","company":"ABC Company","deviceType":"Server","ticketingCompany":"CW Company","method":"Veeam","isVerified":false,"history":[{"status":{"id":3,"name":"Failure"},"lastResultDate":"2025-09-26T00:00:00","isScheduled":true,"daysInStatus":5.3,"date":"2025-09-26T00:00:00","countFailure":1,"countWarning":0,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":5.0,"daysSinceLastGoodResult":-1.0,"resultsCount":1},{"status":{"id":1,"name":"Success"},"lastResultDate":"2025-09-27T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-27T00:00:00","countFailure":0,"countWarning":0,"countSuccess":1,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":0.3,"resultsCount":1}],"results":{"2025-09-27T00:00:00":[{"dateTime":"2025-09-27T05:00:00","success":true,"warning":false,"failure":false,"manual":false,"resultId":"1000_638945460000000000_1"}],"2025-09-26T00:00:00":[{"dateTime":"2025-09-26T04:00:00","success":true,"warning":false,"failure":false,"manual":false,"resultId":"1000_638944560000000000_4"}]}},{"id":1001,"job":"BR Daily Report","device":"BR-OD21","company":"DEF Company","deviceType":"Server","ticketingCompany":"CW Company","method":"Veeam","isVerified":true,"history":[{"status":{"id":2,"name":"Warning"},"lastResultDate":"2025-09-29T00:00:00","isScheduled":true,"daysInStatus":2.0,"date":"2025-09-29T00:00:00","countFailure":0,"countWarning":1,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":1.0,"daysSinceLastGoodResult":-1.0,"resultsCount":1},{"status":{"id":3,"name":"Failure"},"lastResultDate":"2025-09-30T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-30T00:00:00","countFailure":1,"countWarning":0,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":-1.0,"resultsCount":1}],"results":{}}]}
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBrightGaugeBackup, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":2,"Page":1,"PageSize":10,"TotalPages":1,"Results":[{"id":1000,"job":"BR Daily Report","device":"BR-VK24","company":"ABC Company","deviceType":"Server","ticketingCompany":"CW Company","method":"Veeam","isVerified":false,"history":[{"status":{"id":3,"name":"Failure"},"lastResultDate":"2025-09-26T00:00:00","isScheduled":true,"daysInStatus":5.3,"date":"2025-09-26T00:00:00","countFailure":1,"countWarning":0,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":5.0,"daysSinceLastGoodResult":-1.0,"resultsCount":1},{"status":{"id":1,"name":"Success"},"lastResultDate":"2025-09-27T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-27T00:00:00","countFailure":0,"countWarning":0,"countSuccess":1,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":0.3,"resultsCount":1}],"results":{"2025-09-27T00:00:00":[{"dateTime":"2025-09-27T05:00:00","success":true,"warning":false,"failure":false,"manual":false,"resultId":"1000_638945460000000000_1"}],"2025-09-26T00:00:00":[{"dateTime":"2025-09-26T04:00:00","success":true,"warning":false,"failure":false,"manual":false,"resultId":"1000_638944560000000000_4"}]}},{"id":1001,"job":"BR Daily Report","device":"BR-OD21","company":"DEF Company","deviceType":"Server","ticketingCompany":"CW Company","method":"Veeam","isVerified":true,"history":[{"status":{"id":2,"name":"Warning"},"lastResultDate":"2025-09-29T00:00:00","isScheduled":true,"daysInStatus":2.0,"date":"2025-09-29T00:00:00","countFailure":0,"countWarning":1,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":1.0,"daysSinceLastGoodResult":-1.0,"resultsCount":1},{"status":{"id":3,"name":"Failure"},"lastResultDate":"2025-09-30T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-30T00:00:00","countFailure":1,"countWarning":0,"countSuccess":0,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":-1.0,"resultsCount":1}],"results":{}}]}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Invalid ApiKey"
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Invalid ApiKey"
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Invalid ApiKey"
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": [ ]
+          }
+        ]
+      }
+    },
+    "/backups/{backupId}": {
+      "get": {
+        "tags": [
+          "Backups"
+        ],
+        "summary": "Get backups data.",
+        "description": "Returns backup data for specific day.\n            \nThrottling policy: not often than 1 request per 0.5 seconds.",
+        "parameters": [
+          {
+            "name": "backupId",
+            "in": "path",
+            "description": "Backup Id.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "description": "Date. <para />(Example: 2018-02-14).",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiBackup"
+                },
+                "example": {"ticketingCompany":"CW Company","status":{"id":2,"name":"Warning"},"daysInStatus":0.24,"isVerified":false,"lastResult":"2025-10-01T14:42:20","lastSuccess":"2025-10-01T14:42:20","ticketCount":1,"failureThreshold":3.0,"treatWarningAsSuccess":true,"note":"Some note from user","dayStartHour":0,"tags":["Veeam"],"standalone":true,"history":[{"status":{"id":1,"name":"Success"},"lastResultDate":"2025-09-30T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-30T00:00:00","countFailure":0,"countWarning":0,"countSuccess":1,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":0.3,"resultsCount":1}],"backupId":1003,"companyName":"XYZ Company","deviceName":"BR-DVS01","deviceType":"Server","jobName":"BR Daily Report","methodName":"Veeam","backupType":{"id":0,"name":"Backup"}}
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiBackup"
+                },
+                "example": {"ticketingCompany":"CW Company","status":{"id":2,"name":"Warning"},"daysInStatus":0.24,"isVerified":false,"lastResult":"2025-10-01T14:42:20","lastSuccess":"2025-10-01T14:42:20","ticketCount":1,"failureThreshold":3.0,"treatWarningAsSuccess":true,"note":"Some note from user","dayStartHour":0,"tags":["Veeam"],"standalone":true,"history":[{"status":{"id":1,"name":"Success"},"lastResultDate":"2025-09-30T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-30T00:00:00","countFailure":0,"countWarning":0,"countSuccess":1,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":0.3,"resultsCount":1}],"backupId":1003,"companyName":"XYZ Company","deviceName":"BR-DVS01","deviceType":"Server","jobName":"BR Daily Report","methodName":"Veeam","backupType":{"id":0,"name":"Backup"}}
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiBackup"
+                },
+                "example": {"ticketingCompany":"CW Company","status":{"id":2,"name":"Warning"},"daysInStatus":0.24,"isVerified":false,"lastResult":"2025-10-01T14:42:20","lastSuccess":"2025-10-01T14:42:20","ticketCount":1,"failureThreshold":3.0,"treatWarningAsSuccess":true,"note":"Some note from user","dayStartHour":0,"tags":["Veeam"],"standalone":true,"history":[{"status":{"id":1,"name":"Success"},"lastResultDate":"2025-09-30T00:00:00","isScheduled":true,"daysInStatus":0.3,"date":"2025-09-30T00:00:00","countFailure":0,"countWarning":0,"countSuccess":1,"countNoResult":0,"daysSinceLastResult":0.3,"daysSinceLastGoodResult":0.3,"resultsCount":1}],"backupId":1003,"companyName":"XYZ Company","deviceName":"BR-DVS01","deviceType":"Server","jobName":"BR Daily Report","methodName":"Veeam","backupType":{"id":0,"name":"Backup"}}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "There is no backup #1004 scheduled for 9/30/2025"
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "There is no backup #1004 scheduled for 9/30/2025"
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "There is no backup #1004 scheduled for 9/30/2025"
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": [ ]
+          }
+        ]
+      }
+    },
+    "/backups/{backupId}/results": {
+      "get": {
+        "tags": [
+          "Backups"
+        ],
+        "summary": "Get results for backups for date.",
+        "description": "Returns all backup results for a given date.\n            \nThrottling backups: not often than 1 request per 0.5 seconds.",
+        "parameters": [
+          {
+            "name": "backupId",
+            "in": "path",
+            "description": "Backup Id.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "description": "Date. <para />(Example: 2018-02-14).",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.ApiResult, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":2,"Page":1,"PageSize":-1,"TotalPages":2,"Results":[{"dateTime":"2022-05-03T02:00:10","success":true,"warning":false,"failure":false,"manual":false,"resultId":"2151798_637871400100000000_1"},{"dateTime":"2022-05-05T02:00:03","success":false,"warning":false,"failure":true,"manual":false,"resultId":"2151798_637873128030000000_4"}]}
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.ApiResult, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":2,"Page":1,"PageSize":-1,"TotalPages":2,"Results":[{"dateTime":"2022-05-03T02:00:10","success":true,"warning":false,"failure":false,"manual":false,"resultId":"2151798_637871400100000000_1"},{"dateTime":"2022-05-05T02:00:03","success":false,"warning":false,"failure":true,"manual":false,"resultId":"2151798_637873128030000000_4"}]}
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.ApiResult, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":2,"Page":1,"PageSize":-1,"TotalPages":2,"Results":[{"dateTime":"2022-05-03T02:00:10","success":true,"warning":false,"failure":false,"manual":false,"resultId":"2151798_637871400100000000_1"},{"dateTime":"2022-05-05T02:00:03","success":false,"warning":false,"failure":true,"manual":false,"resultId":"2151798_637873128030000000_4"}]}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Invalid ApiKey"
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Invalid ApiKey"
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Invalid ApiKey"
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": [ ]
+          }
+        ]
+      }
+    },
+    "/backups/filters": {
+      "get": {
+        "tags": [
+          "Backups"
+        ],
+        "summary": "Get the available filters.",
+        "description": "Returns the available filters such as Tags, Companies, Statuses, etc.\n            \nThrottling policy: not often than 1 request per 0.5 seconds.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {"deviceTypes":["Server","Workstation"],"companies":["ABC Company","DEF Company","GHI Company","JKL Company","NOP Company","QRS Company","TUV Company","WWW Company","XYZ Company"],"backupMethods":["Veeam","Altaro","AWS","BackupExec","Datto","Windows Backups","Replibit API"],"statuses":["Success","Warning","Failure","No Result","Pending"],"tags":["Important","Chris","Mike","Jake","Ignore","Manual"],"policyTypes":["Backup","Alert"]}
+              },
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {"deviceTypes":["Server","Workstation"],"companies":["ABC Company","DEF Company","GHI Company","JKL Company","NOP Company","QRS Company","TUV Company","WWW Company","XYZ Company"],"backupMethods":["Veeam","Altaro","AWS","BackupExec","Datto","Windows Backups","Replibit API"],"statuses":["Success","Warning","Failure","No Result","Pending"],"tags":["Important","Chris","Mike","Jake","Ignore","Manual"],"policyTypes":["Backup","Alert"]}
+              },
+              "text/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {"deviceTypes":["Server","Workstation"],"companies":["ABC Company","DEF Company","GHI Company","JKL Company","NOP Company","QRS Company","TUV Company","WWW Company","XYZ Company"],"backupMethods":["Veeam","Altaro","AWS","BackupExec","Datto","Windows Backups","Replibit API"],"statuses":["Success","Warning","Failure","No Result","Pending"],"tags":["Important","Chris","Mike","Jake","Ignore","Manual"],"policyTypes":["Backup","Alert"]}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ApiKey is not provided"
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ApiKey is not provided"
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ApiKey is not provided"
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": [ ]
+          }
+        ]
+      }
+    },
+    "/backups/inactive": {
+      "get": {
+        "tags": [
+          "Backups"
+        ],
+        "summary": "Get inactive backups.",
+        "description": "Returns inactive backups ready to activate.\n            \nThrottling policy: not often than 1 request per 0.5 seconds.",
+        "parameters": [
+          {
+            "name": "SearchByCompanyName",
+            "in": "query",
+            "description": "Search by company name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByDeviceName",
+            "in": "query",
+            "description": "Search by device name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByJobName",
+            "in": "query",
+            "description": "Search by job name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByBackupMethod",
+            "in": "query",
+            "description": "Search by backup method.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByEmailFrom",
+            "in": "query",
+            "description": "Search by email.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByBackupType",
+            "in": "query",
+            "description": "Search by backup type.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Page",
+            "in": "query",
+            "description": "Page number to get from the API. Default: 1.",
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "Size",
+            "in": "query",
+            "description": "Size of the page to get from the API. Default: 50. Max page size: 1000.",
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBackupInactive, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":3,"Page":1,"PageSize":10,"TotalPages":1,"Results":[{"emailFrom":"[Undefined]","lastReceived":"2025-10-01T16:18:20","backupId":12001,"companyName":"[Undefined]","deviceName":"SERVER01","jobName":"OneTwo - (dead0000beef)","methodName":"Datto API","backupType":{"id":0,"name":"Backup"}},{"emailFrom":"[Undefined]","lastReceived":"2025-10-01T05:44:44","backupId":12002,"companyName":"[Undefined]","deviceName":"SERVER01","jobName":"OneTwo - (dead0000beef) - Local Verification","methodName":"Datto API","backupType":{"id":0,"name":"Backup"}},{"emailFrom":"br@example.com","lastReceived":"2025-10-01T11:01:32","backupId":12003,"companyName":"[Undefined]","deviceName":"Laptop 127.0.0.1","jobName":"DVS PC - Screenshot","methodName":"Veeam","backupType":{"id":1,"name":"Alert"}}]}
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBackupInactive, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":3,"Page":1,"PageSize":10,"TotalPages":1,"Results":[{"emailFrom":"[Undefined]","lastReceived":"2025-10-01T16:18:20","backupId":12001,"companyName":"[Undefined]","deviceName":"SERVER01","jobName":"OneTwo - (dead0000beef)","methodName":"Datto API","backupType":{"id":0,"name":"Backup"}},{"emailFrom":"[Undefined]","lastReceived":"2025-10-01T05:44:44","backupId":12002,"companyName":"[Undefined]","deviceName":"SERVER01","jobName":"OneTwo - (dead0000beef) - Local Verification","methodName":"Datto API","backupType":{"id":0,"name":"Backup"}},{"emailFrom":"br@example.com","lastReceived":"2025-10-01T11:01:32","backupId":12003,"companyName":"[Undefined]","deviceName":"Laptop 127.0.0.1","jobName":"DVS PC - Screenshot","methodName":"Veeam","backupType":{"id":1,"name":"Alert"}}]}
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBackupInactive, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":3,"Page":1,"PageSize":10,"TotalPages":1,"Results":[{"emailFrom":"[Undefined]","lastReceived":"2025-10-01T16:18:20","backupId":12001,"companyName":"[Undefined]","deviceName":"SERVER01","jobName":"OneTwo - (dead0000beef)","methodName":"Datto API","backupType":{"id":0,"name":"Backup"}},{"emailFrom":"[Undefined]","lastReceived":"2025-10-01T05:44:44","backupId":12002,"companyName":"[Undefined]","deviceName":"SERVER01","jobName":"OneTwo - (dead0000beef) - Local Verification","methodName":"Datto API","backupType":{"id":0,"name":"Backup"}},{"emailFrom":"br@example.com","lastReceived":"2025-10-01T11:01:32","backupId":12003,"companyName":"[Undefined]","deviceName":"Laptop 127.0.0.1","jobName":"DVS PC - Screenshot","methodName":"Veeam","backupType":{"id":1,"name":"Alert"}}]}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ApiKey is not provided"
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ApiKey is not provided"
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ApiKey is not provided"
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": [ ]
+          }
+        ]
+      }
+    },
+    "/backups/retired": {
+      "get": {
+        "tags": [
+          "Backups"
+        ],
+        "summary": "Get retired backups.",
+        "description": "Returns retired backups.\n            \nThrottling policy: not often than 1 request per 0.5 seconds.",
+        "parameters": [
+          {
+            "name": "SearchByCompanyName",
+            "in": "query",
+            "description": "Search by company name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByDeviceName",
+            "in": "query",
+            "description": "Search by device name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByJobName",
+            "in": "query",
+            "description": "Search by job name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByBackupMethod",
+            "in": "query",
+            "description": "Search by backup method.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByEmailFrom",
+            "in": "query",
+            "description": "Search by email.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByRetireMessage",
+            "in": "query",
+            "description": "Search by retire message.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByRetiredBy",
+            "in": "query",
+            "description": "Search by user who retired backup.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SearchByRetiredDateStart",
+            "in": "query",
+            "description": "Search by retired backup date start.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "SearchByRetiredDateEnd",
+            "in": "query",
+            "description": "Search by retired backup date end.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "Page",
+            "in": "query",
+            "description": "Page number to get from the API. Default: 1.",
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "Size",
+            "in": "query",
+            "description": "Size of the page to get from the API. Default: 50. Max page size: 1000.",
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBackupInactive, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":2,"Page":1,"PageSize":10,"TotalPages":1,"Results":[{"RetireMessage":"test message","RetiredDate":"2025-09-27T18:42:20","RetiredBy":"[Undefined]","emailFrom":"[Undefined]","lastReceived":"2025-09-26T18:42:20","backupId":12004,"companyName":"OneTwo Inc.","deviceName":"SERVER01","jobName":"OneTwo - (dead0000beef)","methodName":"Datto API","backupType":{"id":0,"name":"Backup"}},{"RetireMessage":"test message","RetiredDate":"2025-09-28T18:42:20","RetiredBy":"br@example.com","emailFrom":"br@example.com","lastReceived":"2025-09-27T18:42:20","backupId":12005,"companyName":"Liberty LLC","deviceName":"Laptop 127.0.0.2","jobName":"JFK - Screenshot","methodName":"Veeam","backupType":{"id":1,"name":"Alert"}}]}
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBackupInactive, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":2,"Page":1,"PageSize":10,"TotalPages":1,"Results":[{"RetireMessage":"test message","RetiredDate":"2025-09-27T18:42:20","RetiredBy":"[Undefined]","emailFrom":"[Undefined]","lastReceived":"2025-09-26T18:42:20","backupId":12004,"companyName":"OneTwo Inc.","deviceName":"SERVER01","jobName":"OneTwo - (dead0000beef)","methodName":"Datto API","backupType":{"id":0,"name":"Backup"}},{"RetireMessage":"test message","RetiredDate":"2025-09-28T18:42:20","RetiredBy":"br@example.com","emailFrom":"br@example.com","lastReceived":"2025-09-27T18:42:20","backupId":12005,"companyName":"Liberty LLC","deviceName":"Laptop 127.0.0.2","jobName":"JFK - Screenshot","methodName":"Veeam","backupType":{"id":1,"name":"Alert"}}]}
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBackupInactive, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                },
+                "example": {"Total":2,"Page":1,"PageSize":10,"TotalPages":1,"Results":[{"RetireMessage":"test message","RetiredDate":"2025-09-27T18:42:20","RetiredBy":"[Undefined]","emailFrom":"[Undefined]","lastReceived":"2025-09-26T18:42:20","backupId":12004,"companyName":"OneTwo Inc.","deviceName":"SERVER01","jobName":"OneTwo - (dead0000beef)","methodName":"Datto API","backupType":{"id":0,"name":"Backup"}},{"RetireMessage":"test message","RetiredDate":"2025-09-28T18:42:20","RetiredBy":"br@example.com","emailFrom":"br@example.com","lastReceived":"2025-09-27T18:42:20","backupId":12005,"companyName":"Liberty LLC","deviceName":"Laptop 127.0.0.2","jobName":"JFK - Screenshot","methodName":"Veeam","backupType":{"id":1,"name":"Alert"}}]}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ApiKey is not provided"
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ApiKey is not provided"
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ApiKey is not provided"
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": [ ]
+          }
+        ]
+      }
+    },
+    "/backups/overview": {
+      "get": {
+        "tags": [
+          "Backups"
+        ],
+        "summary": "Get overview counts.",
+        "description": "Get amount of policies, backups, servers and workstations.\n            \nThrottling policy: not often than 1 request per 0.5 seconds.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiOverviewCounts"
+                },
+                "example": {"backups":1056,"office365":44,"workstations":10,"activePolicies":1280,"inactivePolicies":76,"retiredPolicies":549}
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiOverviewCounts"
+                },
+                "example": {"backups":1056,"office365":44,"workstations":10,"activePolicies":1280,"inactivePolicies":76,"retiredPolicies":549}
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiOverviewCounts"
+                },
+                "example": {"backups":1056,"office365":44,"workstations":10,"activePolicies":1280,"inactivePolicies":76,"retiredPolicies":549}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ApiKey is not provided"
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ApiKey is not provided"
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ApiKey is not provided"
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Quota exceeded. Maximum requests allowed: 1 per 5s. Please try again in 4 second(s)."
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": [ ]
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BackupRadar.Models.PublicAPI.ApiIdName": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupRadar.Models.PublicAPI.ApiResult": {
+        "type": "object",
+        "properties": {
+          "dateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "success": {
+            "type": "boolean"
+          },
+          "warning": {
+            "type": "boolean"
+          },
+          "failure": {
+            "type": "boolean"
+          },
+          "manual": {
+            "type": "boolean"
+          },
+          "resultId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupRadar.Models.PublicAPI.V2.ApiBackup": {
+        "type": "object",
+        "properties": {
+          "ticketingCompany": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.ApiIdName"
+          },
+          "daysInStatus": {
+            "type": "number",
+            "format": "double"
+          },
+          "isVerified": {
+            "type": "boolean"
+          },
+          "lastResult": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastSuccess": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "ticketCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "failureThreshold": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "treatWarningAsSuccess": {
+            "type": "boolean"
+          },
+          "note": {
+            "type": "string",
+            "nullable": true
+          },
+          "dayStartHour": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "standalone": {
+            "type": "boolean"
+          },
+          "history": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiBackupsHistory"
+            },
+            "nullable": true
+          },
+          "backupId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "companyName": {
+            "type": "string",
+            "nullable": true
+          },
+          "deviceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "deviceType": {
+            "type": "string",
+            "nullable": true
+          },
+          "jobName": {
+            "type": "string",
+            "nullable": true
+          },
+          "methodName": {
+            "type": "string",
+            "nullable": true
+          },
+          "backupType": {
+            "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.ApiIdName"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupRadar.Models.PublicAPI.V2.ApiBackupInactive": {
+        "type": "object",
+        "properties": {
+          "emailFrom": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastReceived": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "backupId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "companyName": {
+            "type": "string",
+            "nullable": true
+          },
+          "deviceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "deviceType": {
+            "type": "string",
+            "nullable": true
+          },
+          "jobName": {
+            "type": "string",
+            "nullable": true
+          },
+          "methodName": {
+            "type": "string",
+            "nullable": true
+          },
+          "backupType": {
+            "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.ApiIdName"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupRadar.Models.PublicAPI.V2.ApiBackupsHistory": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.ApiIdName"
+          },
+          "lastResultDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isScheduled": {
+            "type": "boolean"
+          },
+          "daysInStatus": {
+            "type": "number",
+            "format": "double"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "countFailure": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "countWarning": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "countSuccess": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "countNoResult": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "daysSinceLastResult": {
+            "type": "number",
+            "format": "double"
+          },
+          "daysSinceLastGoodResult": {
+            "type": "number",
+            "format": "double"
+          },
+          "resultsCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupRadar.Models.PublicAPI.V2.ApiBrightGaugeBackup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "job": {
+            "type": "string",
+            "nullable": true
+          },
+          "device": {
+            "type": "string",
+            "nullable": true
+          },
+          "company": {
+            "type": "string",
+            "nullable": true
+          },
+          "deviceType": {
+            "type": "string",
+            "nullable": true
+          },
+          "ticketingCompany": {
+            "type": "string",
+            "nullable": true
+          },
+          "method": {
+            "type": "string",
+            "nullable": true
+          },
+          "isVerified": {
+            "type": "boolean"
+          },
+          "history": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiBackupsHistory"
+            },
+            "nullable": true
+          },
+          "results": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.ApiResult"
+              },
+              "nullable": true
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupRadar.Models.PublicAPI.V2.ApiOverviewCounts": {
+        "type": "object",
+        "properties": {
+          "backups": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "office365": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "workstations": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "activePolicies": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "inactivePolicies": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "retiredPolicies": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.ApiResult, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]": {
+        "type": "object",
+        "properties": {
+          "Total": {
+            "type": "integer",
+            "description": "Total results.",
+            "format": "int32"
+          },
+          "Page": {
+            "type": "integer",
+            "description": "Page number (starting from 1).",
+            "format": "int32"
+          },
+          "PageSize": {
+            "type": "integer",
+            "description": "Items per page.",
+            "format": "int32"
+          },
+          "TotalPages": {
+            "type": "integer",
+            "description": "Total pages.",
+            "format": "int32",
+            "readOnly": true
+          },
+          "Results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.ApiResult"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBackup, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]": {
+        "type": "object",
+        "properties": {
+          "Total": {
+            "type": "integer",
+            "description": "Total results.",
+            "format": "int32"
+          },
+          "Page": {
+            "type": "integer",
+            "description": "Page number (starting from 1).",
+            "format": "int32"
+          },
+          "PageSize": {
+            "type": "integer",
+            "description": "Items per page.",
+            "format": "int32"
+          },
+          "TotalPages": {
+            "type": "integer",
+            "description": "Total pages.",
+            "format": "int32",
+            "readOnly": true
+          },
+          "Results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiBackup"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBackupInactive, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]": {
+        "type": "object",
+        "properties": {
+          "Total": {
+            "type": "integer",
+            "description": "Total results.",
+            "format": "int32"
+          },
+          "Page": {
+            "type": "integer",
+            "description": "Page number (starting from 1).",
+            "format": "int32"
+          },
+          "PageSize": {
+            "type": "integer",
+            "description": "Items per page.",
+            "format": "int32"
+          },
+          "TotalPages": {
+            "type": "integer",
+            "description": "Total pages.",
+            "format": "int32",
+            "readOnly": true
+          },
+          "Results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiBackupInactive"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupRadar.Models.PublicAPI.V2.ApiPaginatedViewModel`1[[BackupRadar.Models.PublicAPI.V2.ApiBrightGaugeBackup, BackupRadar.Models, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]": {
+        "type": "object",
+        "properties": {
+          "Total": {
+            "type": "integer",
+            "description": "Total results.",
+            "format": "int32"
+          },
+          "Page": {
+            "type": "integer",
+            "description": "Page number (starting from 1).",
+            "format": "int32"
+          },
+          "PageSize": {
+            "type": "integer",
+            "description": "Items per page.",
+            "format": "int32"
+          },
+          "TotalPages": {
+            "type": "integer",
+            "description": "Total pages.",
+            "format": "int32",
+            "readOnly": true
+          },
+          "Results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BackupRadar.Models.PublicAPI.V2.ApiBrightGaugeBackup"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "Please provide your API Key.",
+        "name": "ApiKey",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/packages/backupradar-mcp/src/index.ts
+++ b/packages/backupradar-mcp/src/index.ts
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  Tool,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  BackupRadarClient,
+  BackupRadarConfig,
+  QueryParams,
+} from "./backupradar-client.js";
+
+const rawTimeoutMs = process.env.BACKUPRADAR_TIMEOUT_MS
+  ? Number.parseInt(process.env.BACKUPRADAR_TIMEOUT_MS, 10)
+  : undefined;
+const timeoutMs = Number.isFinite(rawTimeoutMs ?? NaN)
+  ? rawTimeoutMs
+  : undefined;
+
+const config: BackupRadarConfig = {
+  baseUrl:
+    process.env.BACKUPRADAR_BASE_URL || "https://api-eu.backupradar.com/v2",
+  apiKey: process.env.BACKUPRADAR_API_KEY || "",
+  apiKeyHeader: process.env.BACKUPRADAR_API_KEY_HEADER || "ApiKey",
+  timeoutMs,
+  userAgent: process.env.BACKUPRADAR_USER_AGENT,
+};
+
+if (!config.apiKey) {
+  console.error("Missing required environment variable BACKUPRADAR_API_KEY.");
+  console.error(
+    "Set BACKUPRADAR_API_KEY and optionally BACKUPRADAR_BASE_URL, BACKUPRADAR_API_KEY_HEADER, BACKUPRADAR_TIMEOUT_MS, BACKUPRADAR_USER_AGENT."
+  );
+  process.exit(1);
+}
+
+const backupRadarClient = new BackupRadarClient(config);
+
+const server = new Server(
+  {
+    name: "backupradar-mcp",
+    version: "0.1.0",
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+const tools: Tool[] = [
+  {
+    name: "backupradar_list_backups",
+    description:
+      "List backups (/backups) with optional filters for company, device, status, and pagination. Mirrors the mocked BackupRadar endpoint.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        page: {
+          type: "number",
+          description: "Page number to request (default: 1).",
+        },
+        size: {
+          type: "number",
+          description: "Number of records to return (default: 3).",
+        },
+        searchCompanyName: {
+          type: "string",
+          description: "Filter by company name.",
+        },
+        searchDeviceName: {
+          type: "string",
+          description: "Filter by device name.",
+        },
+        searchJobName: { type: "string", description: "Filter by job name." },
+        searchBackupMethod: {
+          type: "string",
+          description: "Filter by backup method.",
+        },
+        searchTag: { type: "string", description: "Filter by tag." },
+        searchTooltip: {
+          type: "string",
+          description: "Search in tooltip/notes.",
+        },
+        searchString: { type: "string", description: "Generic search text." },
+        date: {
+          type: "string",
+          description:
+            "Optional ISO date stamp used by the mock for history entries.",
+        },
+        daysWithoutSuccess: {
+          type: "number",
+          description: "Minimum days without a successful run.",
+        },
+        historyDays: {
+          type: "number",
+          description: "Number of days of history to include (mock hint).",
+        },
+        filterScheduled: {
+          type: "boolean",
+          description: "Set true to request only scheduled backups.",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Restrict to specific tags.",
+        },
+        statuses: {
+          type: "array",
+          items: { type: "string" },
+          description: "Restrict to specific statuses.",
+        },
+        policyIds: {
+          type: "array",
+          items: { type: "string" },
+          description: "Return specific backup IDs only.",
+        },
+      },
+    },
+  },
+  {
+    name: "backupradar_get_backup",
+    description: "Retrieve a single backup record (/backups/{backupId}).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        backupId: { type: "string", description: "Backup identifier." },
+        date: {
+          type: "string",
+          description: "Optional ISO date to influence mock history.",
+        },
+      },
+      required: ["backupId"],
+    },
+  },
+  {
+    name: "backupradar_get_backup_results",
+    description:
+      "Retrieve backup execution results (/backups/{backupId}/results).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        backupId: { type: "string", description: "Backup identifier." },
+        date: {
+          type: "string",
+          description: "Optional ISO date to seed mock results.",
+        },
+      },
+      required: ["backupId"],
+    },
+  },
+];
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
+
+function getArg<T = unknown>(
+  args: Record<string, unknown> | undefined,
+  key: string,
+  defaultValue?: T
+): T | undefined {
+  if (!args || typeof args !== "object") {
+    return defaultValue;
+  }
+  if (Object.prototype.hasOwnProperty.call(args, key)) {
+    return (args as Record<string, T | undefined>)[key];
+  }
+  return defaultValue;
+}
+
+function requireArg<T = unknown>(
+  args: Record<string, unknown> | undefined,
+  key: string
+): T {
+  const value = getArg<T>(args, key);
+  if (value === undefined || value === null) {
+    throw new Error(`Missing required argument: ${key}`);
+  }
+  return value;
+}
+
+type ScalarQueryValue = string | number | boolean | Date;
+function normalizeScalar(value: unknown): ScalarQueryValue | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  return String(value);
+}
+
+function normalizeQueryValue(
+  value: unknown
+): ScalarQueryValue | ScalarQueryValue[] | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    const normalized = value
+      .map((entry) => normalizeScalar(entry))
+      .filter((entry): entry is ScalarQueryValue => entry !== undefined);
+
+    return normalized.length > 0 ? normalized : undefined;
+  }
+
+  return normalizeScalar(value);
+}
+
+function mapArgsToQuery(
+  args: Record<string, unknown> | undefined,
+  mapping: Record<string, string>
+): QueryParams | undefined {
+  if (!args) return undefined;
+  const query: QueryParams = {};
+
+  Object.entries(mapping).forEach(([argKey, queryKey]) => {
+    const rawValue = getArg(args, argKey);
+    const fallbackValue =
+      argKey === queryKey ? undefined : getArg(args, queryKey);
+    const value = normalizeQueryValue(rawValue ?? fallbackValue);
+    if (value !== undefined) {
+      query[queryKey] = value;
+    }
+  });
+
+  return Object.keys(query).length > 0 ? query : undefined;
+}
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    let response: unknown;
+
+    switch (name) {
+      case "backupradar_list_backups":
+        {
+          const query: QueryParams = {};
+
+          const setIfPresent = (keys: string[], targetKey: string) => {
+            if (!args) return;
+            for (const key of keys) {
+              const val = getArg(args, key);
+              if (val !== undefined && val !== null) {
+                const normalized = normalizeQueryValue(val);
+                if (normalized !== undefined) {
+                  query[targetKey] = normalized;
+                  return;
+                }
+              }
+            }
+          };
+
+          // Correct, Mockoon-compatible param names (case-sensitive)
+          setIfPresent(["page", "Page"], "Page");
+          setIfPresent(["size", "Size"], "Size");
+
+          setIfPresent(
+            ["searchCompanyName", "searchByCompanyName", "SearchByCompanyName"],
+            "searchCompanyName"
+          );
+          setIfPresent(
+            ["searchDeviceName", "searchByDeviceName", "SearchByDeviceName"],
+            "searchDeviceName"
+          );
+          setIfPresent(
+            ["searchJobName", "searchByJobName", "SearchByJobName"],
+            "searchJobName"
+          );
+          setIfPresent(
+            [
+              "searchBackupMethod",
+              "searchByBackupMethod",
+              "SearchByBackupMethod",
+            ],
+            "searchBackupMethod"
+          );
+
+          setIfPresent(
+            ["searchTooltip", "searchByTooltip", "SearchByTooltip"],
+            "searchTooltip"
+          );
+          setIfPresent(
+            ["searchTag", "searchByTag", "SearchByTag"],
+            "searchTag"
+          );
+          setIfPresent(["searchString", "SearchString"], "searchString");
+
+          setIfPresent(["date", "Date"], "date");
+          setIfPresent(
+            ["daysWithoutSuccess", "DaysWithoutSuccess"],
+            "daysWithoutSuccess"
+          );
+          setIfPresent(["historyDays", "HistoryDays"], "historyDays");
+          setIfPresent(
+            ["filterScheduled", "FilterScheduled"],
+            "filterScheduled"
+          );
+
+          setIfPresent(["tags", "Tags"], "tags");
+          setIfPresent(["statuses", "Statuses"], "statuses");
+          setIfPresent(["policyIds", "PolicyIds"], "policyIds");
+
+          response = await backupRadarClient.listBackups(
+            Object.keys(query).length ? query : undefined
+          );
+        }
+        break;
+      case "backupradar_get_backup":
+        response = await backupRadarClient.getBackup(
+          requireArg<string | number>(args, "backupId"),
+          mapArgsToQuery(args, { date: "date" })
+        );
+        break;
+      case "backupradar_get_backup_results":
+        response = await backupRadarClient.getBackupResults(
+          requireArg<string | number>(args, "backupId"),
+          mapArgsToQuery(args, { date: "date" })
+        );
+        break;
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(response, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Error: ${
+            error instanceof Error ? error.message : "Unknown error"
+          }`,
+        },
+      ],
+    };
+  }
+});
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((error) => {
+  console.error("Server error:", error);
+  process.exit(1);
+});

--- a/packages/backupradar-mcp/tsconfig.json
+++ b/packages/backupradar-mcp/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "declarationMap": false,
+    "removeComments": true,
+    "sourceMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,25 @@ importers:
 
   .: {}
 
+  packages/backupradar-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.17.4
+        version: 1.17.4
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.18.0
+      mcp-inspector:
+        specifier: ^1.0.0
+        version: 1.0.0
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.5
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.2
+        
   packages/connectwisepsa-mcp:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
# feat(backupradar-mcp): Add BackupRadar MCP Server with Mockoon-powered offline testing

## Overview
This PR adds a new MCP server package **`@adamhancock/backupradar-mcp`** that exposes BackupRadar backup monitoring data to Model Context Protocol (MCP) clients. It wraps the BackupRadar REST API and provides a clean tool surface for listing backups, reading a single backup, and fetching execution results. A bundled Mockoon environment enables fully offline development and regression testing.

---

## What’s included
- **New package:** `packages/backupradar-mcp`
- **MCP server:** Node-based server exposing BackupRadar data as MCP tools
- **Typed client:** `BackupRadarClient` with `listBackups`, `getBackup`, `getBackupResults`
- **Mockoon environment:** `MockoonBackupRadar.json` for realistic, local testing
- **Docs:** Comprehensive README with install, config, usage, and dev instructions
- **Examples:** End-to-end scenarios and dev commands for local workflows

---

## Why
- Provide a **first-class, typed** integration point between MCP clients and BackupRadar
- Standardize access to **common backup workflows** (review jobs, verify outcomes)
- Enable **offline testing** and CI-friendly workflows through Mockoon
- Support **progressive adoption**: start with the mock, swap in live API via env

---

## New tools (MCP)
| Tool | Route | Purpose |
|---|---|---|
| `backupradar_list_backups` | `GET /backups` | List backups with filters (company, device, method, status, tags) and pagination |
| `backupradar_get_backup` | `GET /backups/{backupId}` | Inspect a single backup’s configuration/details |
| `backupradar_get_backup_results` | `GET /backups/{backupId}/results` | Retrieve execution results/outcomes for a specific backup |

**Notes**
- Responses are returned **verbatim** from BackupRadar (or the mock) to preserve schema fidelity.
- The list endpoint supports familiar filters like `searchCompanyName`, `searchDeviceName`, `searchJobName`, `searchBackupMethod`, `statuses`, `tags`, and paging via `Page`/`Size`.

---

## Configuration
Environment variables (defaults shown where applicable):

```env
BACKUPRADAR_API_KEY=your_api_key                 # required
BACKUPRADAR_BASE_URL=https://api.backupradar.com/v2
BACKUPRADAR_API_KEY_HEADER=ApiKey
BACKUPRADAR_TIMEOUT_MS=30000
BACKUPRADAR_USER_AGENT=my-mcp-integration/1.0
```

### Mock mode (Mockoon)
Ship with:
- `packages/backupradar-mcp/MockoonBackupRadar.json`

Suggested mock `.env`:
```env
BACKUPRADAR_BASE_URL=http://lvh.me:3000
BACKUPRADAR_API_KEY=demo-key
BACKUPRADAR_API_KEY_HEADER=ApiKey
```

**Mock features**
- Echoes key filters to validate round-trip behavior (`searchCompanyName`, `searchDeviceName`, `searchJobName`, `searchBackupMethod`, `tags`, `statuses`, `policyIds`, etc.)
- Generates realistic sample data when filters are omitted, so UI remains populated
- Useful for local dev and CI without touching production data

---

## Developer experience
**Install**
```bash
pnpm add @adamhancock/backupradar-mcp
# or
npm install @adamhancock/backupradar-mcp
```

**Build / Run**
```bash
# monorepo deps
pnpm install

# build only this package
pnpm --filter backupradar-mcp build

# dev mode with .env
cd packages/backupradar-mcp
pnpm dev

# optional: MCP inspector
pnpm inspector
```

---

## Example prompts / flows
- “List BackupRadar backups tagged **Veeam** that haven’t succeeded in **3 days**.”
- “Show configuration for backup **12004** from **yesterday**.”
- “Fetch execution results for backup **12004** on **2025-09-30**.”

---

## Implementation details
- **Typed client** (`BackupRadarClient`) normalizes:
  - Base URL joining and query-string encoding (arrays handled via repeated params)
  - API key/header injection, user agent propagation
  - Timeout + abort handling, JSON parsing, and error surfacing
- **MCP server** (`backupradar-mcp`) maps common argument aliases to the correct query keys expected by the API/mock (case-sensitive where required).
- **Mockoon templates** mirror live shapes to reduce integration drift and make it safe to iterate UI/agents offline.

---

## Backwards compatibility & risks
- **No breaking changes** to existing packages.
- The new package is **opt-in**; enabling it requires explicit install and configuration.
- Mock environment is **best-effort**; for complex, multi-filter scenarios, use a live API connection for final validation.

---

## Testing
- Unit test the `BackupRadarClient` with the Mockoon server running
- Spot-check MCP tool responses in the **inspector**
- Verify pagination and filters (`Page`, `Size`, `search*`, `statuses`, `tags`, `policyIds`) round-trip correctly

---

## Follow-ups (nice to have)
- Add CI job that spins up Mockoon (CLI) and runs a minimal contract test suite
- Expand mock coverage for more edge-case filter combinations
- Add retries/backoff and structured error types for the client

---

## Screenshots / Demos
N/A (headless MCP server); validated with Mockoon + MCP inspector locally.

---

**License:** ISC

---

### Summary
This PR introduces a production-ready **BackupRadar MCP server** with a **typed client** and **offline Mockoon environment**, making it straightforward to build and test MCP-based backup dashboards, assistants, and automations against BackupRadar.
